### PR TITLE
Added `group_id` and `until_group()` to flow

### DIFF
--- a/examples/flow/flow.script
+++ b/examples/flow/flow.script
@@ -88,6 +88,47 @@ function init(self)
 
 		-- play a sprite animation and wait until it is done
 		flow.play_animation("#sprite", "green_walk_once")
+		print("flow.play_animation() is done")
+
+		-- start two parallel flows and store them to the table "foo"
+		print("Parallel flows stored to the table 'foo' are starting")
+		local foo = {}
+
+		-- start a first parallel flow
+		foo[1] = flow.start(function()
+			flow.delay(math.random())
+			print("Parallel flow foo 1 completed")
+		end)
+
+		-- start a second parallel flow
+		foo[2] = flow.start(function()
+			flow.delay(math.random())
+			print("Parallel flow foo 2 completed")
+		end)
+
+		-- wait until all the flows in the table "foo" have completed
+		flow.until_flows(foo)
+		print("All the parallel stored to the table completed")
+
+		-- start two parallel flows with the same group_id "bar"
+		print("Parallel flows with group_id 'bar' are starting")
+
+		-- start a parallel flow with the group_id "bar"
+		flow.parallel_group("bar", function()
+			flow.delay(math.random())
+			print("Parallel flow bar 1 completed")
+		end)
+
+		-- start an another parallel flow with the group_id "bar"
+		flow.parallel_group("bar", function()
+			flow.delay(math.random())
+			print("Parallel flow bar 2 completed")
+		end)
+
+		-- wait until all the flows with the group_id "bar" have completed
+		flow.until_group("bar")
+		print("All the parallel flows with group_id 'bar' completed")
+
 		print("DONE")
 	end)
 	

--- a/ludobits/m/flow.lua
+++ b/ludobits/m/flow.lua
@@ -523,10 +523,11 @@ end
 -- @param group_id identifier of the flows group
 function M.until_group(group_id)
 	assert(group_id)
+	local group_id = ensure_hash(group_id)
 	local group = {}
 
 	for _, instance in pairs(instances) do
-		if instance.group_id == ensure_hash(group_id) then
+		if instance.group_id == group_id then
 			table.insert(group, instance)
 		end
 	end

--- a/test/test_flow.lua
+++ b/test/test_flow.lua
@@ -198,5 +198,31 @@ return function()
 			wait_seconds(0.2)
 			assert(flow_finished)
 		end)
+
+		it("should be possible to pause until flows with the specific group_id complete", function()
+			local flow_finished = false
+			local instance = flow.start(function()
+				flow.parallel_group("foo", function()
+					flow.delay(0.1)
+				end)
+
+				flow.parallel_group("foo", function()
+					flow.delay(0.2)
+				end)
+
+				flow.parallel_group("foo", function()
+					flow.delay(0.3)
+				end)
+
+				flow.until_group("foo")
+				flow_finished = true
+			end)
+
+			wait_seconds(0.2)
+			assert(not flow_finished)
+
+			wait_seconds(0.2)
+			assert(flow_finished)
+		end)
 	end)
 end


### PR DESCRIPTION
Hello,

There is already a `flow.until_flows()` method in the library, which waits for the completion of a certain list of flow instances. But it's not comfortable to use it when the parallel flows are scattered in different functions, modules and components.

So I added the ability to specify a `group_id` option for flows, as well as the function `flow.until_group(group_id)`. the most popular `group_id` in practice will be, hm... *animations* I think! 😄

I have also added examples of using `flow.until_flows()` and `flow.until_group()` to the `flow.script` file.

Cheers!